### PR TITLE
Using -d conflicts with the Scala Native Packager scripts.

### DIFF
--- a/src/main/scala/com/github/fedeoasi/FindDuplicateFiles.scala
+++ b/src/main/scala/com/github/fedeoasi/FindDuplicateFiles.scala
@@ -89,7 +89,7 @@ object FindDuplicateFiles extends Logging {
       .action { case (extension, config) => config.copy(extension = Some(extension)) }
       .text("The extension of the files to be searched")
 
-    opt[Boolean]('d', "show-duplicates")
+    opt[Boolean]('u', "show-duplicates")
       .action { case (showDuplicates, config) => config.copy(showDuplicates = showDuplicates) }
       .text("Print paths of the duplicate files along with the canonical file")
 


### PR DESCRIPTION
* -d is used by the Scala Native Packager scripts as a debug flag.