### PR TITLE
Introduce a single entrypoint for easier command line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ incrementally update the catalog.
 
 ## Tools
 
+- `CliMain`: A single entry point for all the operations described below.  Using this entry point without any arguments will print out descriptive usage instructions.
+
 ### Catalog Operations
 
 - `GenerateCatalog`: Generate the catalog and incrementally add new items

--- a/src/main/scala/com/github/fedeoasi/DeletionChecker.scala
+++ b/src/main/scala/com/github/fedeoasi/DeletionChecker.scala
@@ -34,6 +34,7 @@ object DeletionChecker extends Logging with CliAware {
       .text("The catalog file (csv)")
 
     opt[String]('f', "folder")
+      .required()
       .action { case (folder, config) => config.copy(folder = Some(Paths.get(folder))) }
       .text("The root from which to check for deletions")
 

--- a/src/main/scala/com/github/fedeoasi/DeletionChecker.scala
+++ b/src/main/scala/com/github/fedeoasi/DeletionChecker.scala
@@ -4,9 +4,12 @@ import java.io.File
 import java.nio.file.{Path, Paths}
 
 import com.github.fedeoasi.Model.FileSystemEntry
+import com.github.fedeoasi.cli.{CliAware, CliCommand}
 import scopt.OptionParser
 
-object DeletionChecker extends Logging {
+object DeletionChecker extends Logging with CliAware {
+  override val command = CliCommand("deletion-checker", "Remove entries of deleted files from a catalog file.")
+
   case class DeletionCheckerConfig(catalog: Option[Path] = None, folder: Option[Path] = None)
   case class DeletionCheckerResult(toKeepWithoutCheck: Seq[FileSystemEntry], toKeep: Seq[FileSystemEntry], toDelete: Seq[FileSystemEntry])
 
@@ -22,8 +25,8 @@ object DeletionChecker extends Logging {
     DeletionCheckerResult(toKeepWithoutCheck, toKeep, toDelete)
   }
 
-  private val parser = new OptionParser[DeletionCheckerConfig](getClass.getSimpleName) {
-    head(getClass.getSimpleName)
+  private val parser = new OptionParser[DeletionCheckerConfig](command.name) {
+    head(command.description + "\n")
 
     opt[String]('c', "catalog")
       .required()

--- a/src/main/scala/com/github/fedeoasi/DeletionChecker.scala
+++ b/src/main/scala/com/github/fedeoasi/DeletionChecker.scala
@@ -34,7 +34,6 @@ object DeletionChecker extends Logging with CliAware {
       .text("The catalog file (csv)")
 
     opt[String]('f', "folder")
-      .required()
       .action { case (folder, config) => config.copy(folder = Some(Paths.get(folder))) }
       .text("The root from which to check for deletions")
 

--- a/src/main/scala/com/github/fedeoasi/DiffFolders.scala
+++ b/src/main/scala/com/github/fedeoasi/DiffFolders.scala
@@ -2,7 +2,7 @@ package com.github.fedeoasi
 
 import com.github.fedeoasi.FolderComparison.FolderDiff
 import com.github.fedeoasi.Model._
-import com.github.fedeoasi.cli.{CatalogConfig, CatalogConfigParsing}
+import com.github.fedeoasi.cli.{CatalogConfig, CatalogConfigParsing, CliCommand}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -57,6 +57,8 @@ object DiffFolders extends FolderComparison with Logging {
   * The analysis is performed in parallel using Spark.
   */
 object FindIdenticalFolders extends CatalogConfigParsing with SparkSupport with Logging {
+  override val command = CliCommand("find-identical-folders", "Find identical folders, having the same name and files.")
+
   /** Find identical folders present in the catalog. */
   def main(args: Array[String]): Unit = {
     parser.parse(args, CatalogConfig()) match {
@@ -82,6 +84,8 @@ object FindIdenticalFolders extends CatalogConfigParsing with SparkSupport with 
   * The analysis is performed in parallel using Spark.
   */
 object FindSimilarFolders extends CatalogConfigParsing with Logging with SparkSupport {
+  override val command = CliCommand("find-similar-folders", "Finds similar but not identical folders that have the same name.")
+
   def main(args: Array[String]): Unit = {
     parser.parse(args, CatalogConfig()) match {
       case Some(CatalogConfig(Some(catalog))) =>

--- a/src/main/scala/com/github/fedeoasi/DuplicateFilesFinder.scala
+++ b/src/main/scala/com/github/fedeoasi/DuplicateFilesFinder.scala
@@ -78,7 +78,7 @@ object DuplicateFilesFinder extends Logging with CliAware {
     val topK = if(printAllDups) { None } else { Some(25) }
     val filesAndDuplicates = findDuplicates(entries, folder, topK)
     info(filesAndDuplicates.map { case (canonical, duplicates) =>
-      lazy val dups = duplicates.take(3).map(f => s"    - ${f.path}").mkString("\n")
+      lazy val dups = duplicates.map(f => s"    - ${f.path}").mkString("\n")
       canonical.path + (if (printDups) s"\n$dups" else "")
     }.mkString("\n"))
   }
@@ -100,11 +100,11 @@ object DuplicateFilesFinder extends Logging with CliAware {
       .text("The extension of the files to be searched")
 
     opt[Unit]('u', "show-duplicates")
-      .action { case (showDuplicates, config) => config.copy(showDuplicates = true) }
+      .action { case (_, config) => config.copy(showDuplicates = true) }
       .text("Print paths of the duplicate files along with the canonical file")
 
     opt[Unit]('a', "show-all")
-      .action { case (all, config) => config.copy(showAllDuplicates = true)}
+      .action { case (_, config) => config.copy(showAllDuplicates = true)}
       .text("When showing duplicates, show all the duplicates instead of just the largest.")
 
     help("help").text("prints this usage text")

--- a/src/main/scala/com/github/fedeoasi/ExtensionsByFileCount.scala
+++ b/src/main/scala/com/github/fedeoasi/ExtensionsByFileCount.scala
@@ -3,10 +3,11 @@ package com.github.fedeoasi
 import java.nio.file.Path
 
 import com.github.fedeoasi.Model.{FileEntries, FileEntry, FileSystemEntry}
-import com.github.fedeoasi.cli.{CatalogConfig, CatalogConfigParsing}
+import com.github.fedeoasi.cli.{CatalogConfig, CatalogConfigParsing, CliCommand}
 import com.github.fedeoasi.collection.TopKFinder
 
 object ExtensionsByFileCount extends CatalogConfigParsing with Logging {
+  override val command = CliCommand("extensions-by-filecount", "Rank file extensions by count.")
   case class TopExtensionsResult(extension: String, count: Int, uniqueCount: Int)
 
   def groupByExtension(entries: Seq[FileSystemEntry]): Map[String, Seq[FileEntry]] = {

--- a/src/main/scala/com/github/fedeoasi/FilesBySize.scala
+++ b/src/main/scala/com/github/fedeoasi/FilesBySize.scala
@@ -3,11 +3,12 @@ package com.github.fedeoasi
 import java.text.NumberFormat
 
 import com.github.fedeoasi.Model.{FileEntries, FileEntry}
-import com.github.fedeoasi.cli.{CatalogConfig, CatalogConfigParsing}
+import com.github.fedeoasi.cli.{CatalogConfig, CatalogConfigParsing, CliCommand}
 import com.github.fedeoasi.collection.TopKFinder
 import wvlet.log._
 
 object FilesBySize extends CatalogConfigParsing with Logging {
+  override val command = CliCommand("files-by-size", "Rank files by size.")
   /** Ranks files by size. */
   def main(args: Array[String]): Unit = {
     parser.parse(args, CatalogConfig()) match {
@@ -22,6 +23,7 @@ object FilesBySize extends CatalogConfigParsing with Logging {
 }
 
 object TotalSize extends CatalogConfigParsing with LogSupport {
+  override val command = CliCommand("total-size", "Compute total catalog size.")
   def main(args: Array[String]): Unit = {
     parser.parse(args, CatalogConfig()) match {
       case Some(CatalogConfig(Some(catalog))) =>

--- a/src/main/scala/com/github/fedeoasi/FindDuplicateFilesWithinSecondaryFolder.scala
+++ b/src/main/scala/com/github/fedeoasi/FindDuplicateFilesWithinSecondaryFolder.scala
@@ -1,8 +1,32 @@
 package com.github.fedeoasi
 
-import com.github.fedeoasi.Model.FileEntries
+import java.nio.file.Paths
 
-object FindDuplicateFilesWithinSecondaryFolder extends Logging {
+import com.github.fedeoasi.FindFileByMd5.FindFileByMd5Config
+import com.github.fedeoasi.Model.FileEntries
+import com.github.fedeoasi.cli.{CliAware, CliCommand}
+import scopt.OptionParser
+
+object FindDuplicateFilesWithinSecondaryFolder extends Logging with CliAware {
+  override val command = CliCommand("lookup-duplicates", "Look for duplicate files in specific folders.")
+  private val parser = new OptionParser[FindFileByMd5Config](command.name) {
+    head(command.description + "\n")
+
+    opt[String]('c', "catalog")
+      .action { case (catalog, config) => config.copy(catalog = Some(Paths.get(catalog))) }
+      .text("The catalog file (csv)")
+
+    opt[String]('p', "reference")
+      .action { case (md5, config) => config.copy(md5 = Some(md5)) }
+      .text("The reference folder containing the files to search for")
+
+    opt[String]('s', "search")
+      .action { case (md5, config) => config.copy(md5 = Some(md5)) }
+      .text("The folder to search for duplicates")
+
+    help("help").text("prints this usage text")
+  }
+
   /** Given a source folder lists the files that are duplicated and prints
     * the locations of the duplicates under the given input folder.
     *

--- a/src/main/scala/com/github/fedeoasi/FindDuplicateFilesWithinSecondaryFolder.scala
+++ b/src/main/scala/com/github/fedeoasi/FindDuplicateFilesWithinSecondaryFolder.scala
@@ -1,27 +1,33 @@
 package com.github.fedeoasi
 
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 
-import com.github.fedeoasi.FindFileByMd5.FindFileByMd5Config
 import com.github.fedeoasi.Model.FileEntries
 import com.github.fedeoasi.cli.{CliAware, CliCommand}
 import scopt.OptionParser
 
+case class FindDuplicateFilesWithinSecondaryFolderConfig(catalog: Option[Path] = None,
+                                                         reference: Option[String] = None,
+                                                         search: Option[String] = None)
+
 object FindDuplicateFilesWithinSecondaryFolder extends Logging with CliAware {
   override val command = CliCommand("lookup-duplicates", "Look for duplicate files in specific folders.")
-  private val parser = new OptionParser[FindFileByMd5Config](command.name) {
+  private val parser = new OptionParser[FindDuplicateFilesWithinSecondaryFolderConfig](command.name) {
     head(command.description + "\n")
 
     opt[String]('c', "catalog")
+      .required()
       .action { case (catalog, config) => config.copy(catalog = Some(Paths.get(catalog))) }
       .text("The catalog file (csv)")
 
     opt[String]('p', "reference")
-      .action { case (md5, config) => config.copy(md5 = Some(md5)) }
+      .required()
+      .action { case (ref, config) => config.copy(reference = Some(ref)) }
       .text("The reference folder containing the files to search for")
 
     opt[String]('s', "search")
-      .action { case (md5, config) => config.copy(md5 = Some(md5)) }
+      .required()
+      .action { case (srch, config) => config.copy(search = Some(srch)) }
       .text("The folder to search for duplicates")
 
     help("help").text("prints this usage text")
@@ -33,22 +39,23 @@ object FindDuplicateFilesWithinSecondaryFolder extends Logging with CliAware {
     * @param args [CATALOG] [PRIMARY_FOLDER] [SECONDARY_FOLDER]
     */
   def main(args: Array[String]): Unit = {
-    val catalog = args(0)
-    val primaryFolder = args(1)
-    val secondaryFolder = args(2)
-    require(primaryFolder != secondaryFolder, "Primary and secondary folder must be different")
-    val entries = EntryPersistence.read(catalog)
-    val files = FileEntries(entries)
+    parser.parse(args, FindDuplicateFilesWithinSecondaryFolderConfig()) match {
+      case Some(FindDuplicateFilesWithinSecondaryFolderConfig(Some(catalog), Some(primaryFolder), Some(secondaryFolder))) =>
+        require(primaryFolder != secondaryFolder, "Primary and secondary folder must be different")
+        val entries = EntryPersistence.read(catalog)
+        val files = FileEntries(entries)
 
-    val primaryFiles = files.filter(_.parent == primaryFolder)
-    val secondaryFiles = files.filter(_.parent == secondaryFolder)
+        val primaryFiles = files.filter(_.parent == primaryFolder)
+        val secondaryFiles = files.filter(_.parent == secondaryFolder)
 
-    val primaryFilesByMd5 = primaryFiles.groupBy(_.md5)
+        val primaryFilesByMd5 = primaryFiles.groupBy(_.md5)
 
-    secondaryFiles.foreach { secondaryFile =>
-      if (primaryFilesByMd5.contains(secondaryFile.md5)) {
-        info(secondaryFile.path)
-      }
+        secondaryFiles.foreach { secondaryFile =>
+          if (primaryFilesByMd5.contains(secondaryFile.md5)) {
+            info(secondaryFile.path)
+          }
+        }
+      case _ =>
     }
   }
 }

--- a/src/main/scala/com/github/fedeoasi/FindFileByMd5.scala
+++ b/src/main/scala/com/github/fedeoasi/FindFileByMd5.scala
@@ -3,9 +3,11 @@ package com.github.fedeoasi
 import java.nio.file.{Path, Paths}
 
 import com.github.fedeoasi.Model.{FileEntries, FileEntry}
+import com.github.fedeoasi.cli.{CliAware, CliCommand}
 import scopt.OptionParser
 
-object FindFileByMd5 extends Logging {
+object FindFileByMd5 extends Logging with CliAware {
+  override val command = CliCommand("find-file-by-md5", "Find a single file by MD5 hash.")
   def find(files: Seq[FileEntry], md5: String): Seq[FileEntry] = {
     files.filter(_.md5.exists(_ == md5))
   }
@@ -14,8 +16,8 @@ object FindFileByMd5 extends Logging {
     catalog: Option[Path] = None,
     md5: Option[String] = None)
 
-  private val parser = new OptionParser[FindFileByMd5Config](getClass.getSimpleName) {
-    head(getClass.getSimpleName)
+  private val parser = new OptionParser[FindFileByMd5Config](command.name) {
+    head(command.description + "\n")
 
     opt[String]('c', "catalog")
       .action { case (catalog, config) => config.copy(catalog = Some(Paths.get(catalog))) }

--- a/src/main/scala/com/github/fedeoasi/FolderByName.scala
+++ b/src/main/scala/com/github/fedeoasi/FolderByName.scala
@@ -3,17 +3,19 @@ package com.github.fedeoasi
 import java.nio.file.{Path, Paths}
 
 import com.github.fedeoasi.Model.{DirectoryEntry, FileSystemEntry}
+import com.github.fedeoasi.cli.{CliAware, CliCommand}
 import scopt.OptionParser
 
-object FolderByName extends Logging {
+object FolderByName extends Logging with CliAware {
+  override val command = CliCommand("folder-by-name", "Finds a folder by name (case insensitive).")
   case class FolderByNameConfig(folderName: Option[String] = None, catalog: Option[Path] = None)
 
   def findFoldersByName(folderName: String, entries: Seq[FileSystemEntry]): Seq[DirectoryEntry] = {
     entries.collect { case d: DirectoryEntry if d.name.equalsIgnoreCase(folderName) => d }
   }
 
-  private val parser = new OptionParser[FolderByNameConfig](getClass.getSimpleName) {
-    head(getClass.getSimpleName)
+  private val parser = new OptionParser[FolderByNameConfig](command.name) {
+    head(command.description + "\n")
 
     opt[String]('n', "folderName").required()
       .action { case (folderName, config) => config.copy(folderName = Some(folderName)) }

--- a/src/main/scala/com/github/fedeoasi/FolderSimilarity.scala
+++ b/src/main/scala/com/github/fedeoasi/FolderSimilarity.scala
@@ -2,7 +2,7 @@ package com.github.fedeoasi
 
 import com.github.fedeoasi.DiffFolders._
 import com.github.fedeoasi.Model.{DirectoryEntry, FileSystemEntry}
-import com.github.fedeoasi.cli.{CatalogConfig, CatalogConfigParsing}
+import com.github.fedeoasi.cli.{CatalogConfig, CatalogConfigParsing, CliCommand}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -15,6 +15,7 @@ import org.apache.spark.rdd.RDD
   * - The weights are binary
   */
 object FolderSimilarity extends CatalogConfigParsing with SparkSupport with Logging {
+  override val command = CliCommand("folder-similarity", "Ranks folder pairs by MD5 sum similarity.")
   case class Folder(entry: DirectoryEntry, fileCount: Int)
   case class Score(fileCount1: Int, fileCount2: Int, count: Double) {
     def cosineSimilarity: Double = count / (Math.sqrt(fileCount1) * Math.sqrt(fileCount2))

--- a/src/main/scala/com/github/fedeoasi/FoldersByFileCount.scala
+++ b/src/main/scala/com/github/fedeoasi/FoldersByFileCount.scala
@@ -4,11 +4,11 @@ import java.nio.file.{Path, Paths}
 import java.text.NumberFormat
 
 import com.github.fedeoasi.Model._
-import com.github.fedeoasi.cli.CatalogAndFolderConfig
+import com.github.fedeoasi.cli.{CatalogAndFolderConfig, CliAware, CliCommand}
 import com.github.fedeoasi.collection.TopKFinder
 import scopt.OptionParser
 
-trait FoldersByStat extends Logging {
+trait FoldersByStat extends Logging with CliAware {
   def stats(
     root: Path,
     entriesByParent: Map[String, Seq[FileSystemEntry]],
@@ -35,8 +35,9 @@ trait FoldersByStat extends Logging {
 }
 
 object FoldersByFileCount extends FoldersByStat {
-  private val parser = new OptionParser[CatalogAndFolderConfig](getClass.getSimpleName) {
-    head(getClass.getSimpleName)
+  override val command = CliCommand("folders-by-count", "Ranks folders by file counts.")
+  private val parser = new OptionParser[CatalogAndFolderConfig](command.name) {
+    head(command.description + "\n")
 
     opt[String]('c', "catalog")
       .action { case (catalog, config) => config.copy(catalog = Some(Paths.get(catalog))) }
@@ -72,8 +73,9 @@ object FoldersByFileCount extends FoldersByStat {
 }
 
 object FoldersByFileSize extends FoldersByStat {
-  private val parser = new OptionParser[CatalogAndFolderConfig](getClass.getSimpleName) {
-    head(getClass.getSimpleName)
+  override val command = CliCommand("folders-by-file-size", "Ranks folders by file size.")
+  private val parser = new OptionParser[CatalogAndFolderConfig](command.name) {
+    head(command.description + "\n")
 
     opt[String]('c', "catalog")
       .action { case (catalog, config) => config.copy(catalog = Some(Paths.get(catalog))) }

--- a/src/main/scala/com/github/fedeoasi/FoldersContainingExtension.scala
+++ b/src/main/scala/com/github/fedeoasi/FoldersContainingExtension.scala
@@ -4,9 +4,11 @@ import java.nio.file.{Path, Paths}
 
 import com.github.fedeoasi.ExtensionsByFileCount.groupByExtension
 import com.github.fedeoasi.Model.{FileEntry, FileSystemEntry}
+import com.github.fedeoasi.cli.{CliAware, CliCommand}
 import scopt.OptionParser
 
-object FoldersContainingExtension extends Logging {
+object FoldersContainingExtension extends Logging with CliAware {
+  override val command = CliCommand("folders-having-extension", "Prints folders that contain files with a given extension.")
 
   def foldersContainingExtension(entries: Seq[FileSystemEntry], extension: String): Map[String, Seq[FileEntry]] = {
     groupByExtension(entries).getOrElse(extension, Seq.empty).groupBy(_.parent)

--- a/src/main/scala/com/github/fedeoasi/GenerateCatalog.scala
+++ b/src/main/scala/com/github/fedeoasi/GenerateCatalog.scala
@@ -6,15 +6,18 @@ import java.util.function.Consumer
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.github.fedeoasi.Model.FileSystemEntry
+import com.github.fedeoasi.cli.{CliAware, CliCommand}
 import scopt.OptionParser
 
-object GenerateCatalog extends Logging {
+object GenerateCatalog extends Logging with CliAware {
+  override val command = CliCommand("generate-catalog", "Catalog a directory and save it to a CSV file.")
+
   case class GenerateCatalogReport(added: Long, total: Long)
 
   case class GenerateCatalogConfig(inputFolder: Option[Path] = None, catalog: Option[Path] = None, populateMd5: Boolean = true)
 
-  private val parser = new OptionParser[GenerateCatalogConfig](getClass.getSimpleName) {
-    head(getClass.getSimpleName)
+  private val parser = new OptionParser[GenerateCatalogConfig](command.name) {
+    head(command.description + "\n")
 
     opt[String]('i', "inputFolder")
       .action { case (folder, config) => config.copy(inputFolder = Some(Paths.get(folder))) }

--- a/src/main/scala/com/github/fedeoasi/MergeCatalogs.scala
+++ b/src/main/scala/com/github/fedeoasi/MergeCatalogs.scala
@@ -2,6 +2,7 @@ package com.github.fedeoasi
 
 import java.nio.file.{Path, Paths}
 
+import com.github.fedeoasi.cli.{CliAware, CliCommand}
 import scopt.OptionParser
 
 case class MergeCatalogConfig(
@@ -9,7 +10,8 @@ case class MergeCatalogConfig(
   secondaryCatalog: Option[Path] = None,
   outputCatalog: Option[Path] = None)
 
-object MergeCatalogs {
+object MergeCatalogs extends CliAware {
+  override val command = CliCommand("merge-catalogs", "Merge two catalogs into an output catalog.")
   private val parser = new OptionParser[MergeCatalogConfig](getClass.getSimpleName) {
     head(getClass.getSimpleName)
 

--- a/src/main/scala/com/github/fedeoasi/cli/CatalogConfig.scala
+++ b/src/main/scala/com/github/fedeoasi/cli/CatalogConfig.scala
@@ -11,6 +11,7 @@ trait CatalogConfigParsing extends CliAware {
     head(command.description + "\n")
 
     opt[String]('c', "catalog")
+      .required()
       .action { case (catalog, config) => config.copy(catalog = Some(Paths.get(catalog))) }
       .text("The catalog file (csv)")
 

--- a/src/main/scala/com/github/fedeoasi/cli/CatalogConfig.scala
+++ b/src/main/scala/com/github/fedeoasi/cli/CatalogConfig.scala
@@ -6,9 +6,9 @@ import scopt.OptionParser
 
 case class CatalogConfig(catalog: Option[Path] = None)
 
-trait CatalogConfigParsing {
-  protected val parser = new OptionParser[CatalogConfig](getClass.getSimpleName) {
-    head(getClass.getSimpleName)
+trait CatalogConfigParsing extends CliAware {
+  protected lazy val parser = new OptionParser[CatalogConfig](command.name) {
+    head(command.description + "\n")
 
     opt[String]('c', "catalog")
       .action { case (catalog, config) => config.copy(catalog = Some(Paths.get(catalog))) }
@@ -16,5 +16,4 @@ trait CatalogConfigParsing {
 
     help("help").text("prints this usage text")
   }
-
 }

--- a/src/main/scala/com/github/fedeoasi/cli/CliAware.scala
+++ b/src/main/scala/com/github/fedeoasi/cli/CliAware.scala
@@ -1,0 +1,6 @@
+package com.github.fedeoasi.cli
+
+trait CliAware {
+  def command: CliCommand
+  def main(args: Array[String]): Unit
+}

--- a/src/main/scala/com/github/fedeoasi/cli/CliCommand.scala
+++ b/src/main/scala/com/github/fedeoasi/cli/CliCommand.scala
@@ -1,0 +1,9 @@
+package com.github.fedeoasi.cli
+
+case class CliCommand(name: String, description: String) {
+  private val MAX_COMMAND_NAME_LENGTH = 23
+  override def toString: String = {
+    val spacer = "  " + " " * Math.max(0, MAX_COMMAND_NAME_LENGTH - name.length)
+    name + spacer + description
+  }
+}

--- a/src/main/scala/com/github/fedeoasi/cli/CliMain.scala
+++ b/src/main/scala/com/github/fedeoasi/cli/CliMain.scala
@@ -1,0 +1,38 @@
+package com.github.fedeoasi.cli
+
+import com.github.fedeoasi._
+
+object CliMain {
+  val commands: Map[String, List[CliAware]] = Map(
+    "Catalog creation and update" -> List(GenerateCatalog, DeletionChecker, MergeCatalogs),
+    "Lookup" -> List(FolderByName, FindFileByMd5, FoldersContainingExtension),
+    "Finding duplicates" -> List(DuplicateFilesFinder, FolderSimilarity, FindIdenticalFolders, FindSimilarFolders, FindDuplicateFilesWithinSecondaryFolder),
+    "Catalog statistics" -> List(FilesBySize, ExtensionsByFileCount)
+  )
+
+  def main(args: Array[String]): Unit = {
+    if(args.length == 0) {
+      printUsage()
+    } else {
+      val commandName = args(0)
+      commands.values.flatten.find(_.command.name == commandName) match {
+        case None =>
+          println(s"Unknown command: $commandName\n")
+          printUsage()
+        case Some(command) =>
+          val commandArgs = args.drop(1)
+          command.main(commandArgs)
+      }
+    }
+  }
+
+  private def printUsage(): Unit = {
+    println("Catalog-driven utilities for finding duplicate files.\n")
+    commands.foreach(group => {
+      println(group._1 + ":")
+      group._2.map("  " + _.command.toString).foreach(println)
+      println()
+    })
+    println("Use \"<command> --help\" for more information about a given command.")
+  }
+}

--- a/src/test/scala/com/github/fedeoasi/FindDuplicateFilesTest.scala
+++ b/src/test/scala/com/github/fedeoasi/FindDuplicateFilesTest.scala
@@ -17,7 +17,7 @@ class FindDuplicateFilesTest extends FunSpec with Matchers with TemporaryFiles {
     val otherFolder = baseDir.resolve("OtherFolder")
 
     it("finds all duplicates") {
-      val finder = new FindDuplicateFiles(entries)
+      val finder = new DuplicateFilesFinder(entries)
       paths(finder.filesAndDuplicates) should contain theSameElementsAs Seq(
         dirWithDuplicates.resolve("b.txt").toString -> Seq(dirWithDuplicates.resolve("c.txt").toString),
         noDuplicatesDir.resolve("d.txt").toString -> Seq(otherFolder.resolve("e.txt").toString)
@@ -25,36 +25,36 @@ class FindDuplicateFilesTest extends FunSpec with Matchers with TemporaryFiles {
     }
 
     it("finds all duplicates for a folder") {
-      val finder = new FindDuplicateFiles(entries, Some(noDuplicatesDir))
+      val finder = new DuplicateFilesFinder(entries, Some(noDuplicatesDir))
       paths(finder.filesAndDuplicates) should contain theSameElementsAs Seq(
         noDuplicatesDir.resolve("d.txt").toString -> Seq(otherFolder.resolve("e.txt").toString)
       )
     }
 
     it("finds all duplicates for a folder that itself contains duplicates") {
-      val finder = new FindDuplicateFiles(entries, Some(dirWithDuplicates))
+      val finder = new DuplicateFilesFinder(entries, Some(dirWithDuplicates))
       paths(finder.filesAndDuplicates) should contain theSameElementsAs Seq(
         dirWithDuplicates.resolve("b.txt").toString -> Seq(dirWithDuplicates.resolve("c.txt").toString)
       )
     }
 
     it("finds the largest duplicate") {
-      val finder = new FindDuplicateFiles(entries)
-      paths(finder.largestDuplicates(1)) should contain theSameElementsAs Seq(
+      val finder = new DuplicateFilesFinder(entries)
+      paths(finder.largestDuplicates(Some(1))) should contain theSameElementsAs Seq(
         noDuplicatesDir.resolve("d.txt").toString -> Seq(otherFolder.resolve("e.txt").toString)
       )
     }
 
     it("only finds one largest duplicate for a folder with just one duplicate") {
-      val finder = new FindDuplicateFiles(entries, Some(dirWithDuplicates))
-      paths(finder.largestDuplicates(3)) should contain theSameElementsAs Seq(
+      val finder = new DuplicateFilesFinder(entries, Some(dirWithDuplicates))
+      paths(finder.largestDuplicates(Some(3))) should contain theSameElementsAs Seq(
         dirWithDuplicates.resolve("b.txt").toString -> Seq(dirWithDuplicates.resolve("c.txt").toString)
       )
     }
 
     it("finds the largest duplicates") {
-      val finder = new FindDuplicateFiles(entries)
-      paths(finder.largestDuplicates(10)) should contain theSameElementsAs Seq(
+      val finder = new DuplicateFilesFinder(entries)
+      paths(finder.largestDuplicates(Some(10))) should contain theSameElementsAs Seq(
         noDuplicatesDir.resolve("d.txt").toString -> Seq(otherFolder.resolve("e.txt").toString),
         dirWithDuplicates.resolve("b.txt").toString -> Seq(dirWithDuplicates.resolve("c.txt").toString)
       )

--- a/src/test/scala/com/github/fedeoasi/cli/CliCommandTest.scala
+++ b/src/test/scala/com/github/fedeoasi/cli/CliCommandTest.scala
@@ -1,0 +1,20 @@
+package com.github.fedeoasi.cli
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class CliCommandTest extends FlatSpec with Matchers {
+  "CliCommand" should "output valid string" in {
+    val command = CliCommand("0123456789001234567890123", "desc")
+    command.toString should be("0123456789001234567890123  desc")
+  }
+
+  it should "handle longer names properly" in {
+    val command = CliCommand("012345678901234567890123456789", "desc")
+    command.toString should be("012345678901234567890123456789  desc")
+  }
+
+  it should "handle shorter names properly" in {
+    val command = CliCommand("0123456789", "desc")
+    command.toString should be("0123456789               desc")
+  }
+}


### PR DESCRIPTION
Introducing a `CliMain` entrypoint that documents the command usage.  When using the entrypoint with no arguments, the following is output:

```
Catalog-driven utilities for finding duplicate files.

Catalog creation and update:
  generate-catalog         Catalog a directory and save it to a CSV file.
  deletion-checker         Remove entries of deleted files from a catalog file.
  merge-catalogs           Merge two catalogs into an output catalog.

Lookup:
  folder-by-name           Finds a folder by name (case insensitive).
  find-file-by-md5         Find a single file by MD5 hash.
  folders-having-extension  Prints folders that contain files with a given extension.

Finding duplicates:
  find-duplicate-files     Find duplicate files in a catalog file.
  folder-similarity        Ranks folder pairs by MD5 sum similarity.
  find-identical-folders   Find identical folders, having the same name and files.
  find-similar-folders     Finds similar but not identical folders that have the same name.
  lookup-duplicates        Look for duplicate files in specific folders.

Catalog statistics:
  files-by-size            Rank files by size.
  extensions-by-filecount  Rank file extensions by count.

Use "<command> --help" for more information about a given command.
```

Digging deeper, you can then run the entrypoint with a command name and `--help`.  For example `folder-by-name --help` gives:
```
Finds a folder by name (case insensitive).

Usage: folder-by-name [options]

  -n, --folderName <value>
                           The root folder from which to generate a catalog
  -c, --catalog <value>    The catalog file (csv)
  --help                   prints this usage text
```

I also tweaked the `DuplicateFilesFinder` options parser to not require values for boolean arguments.

## Summary
* Single command to use on the CLI
* Documents all the commands and their arguments
